### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "markri/wp-sec",
     "description": "Checks Wordpress installation for CVE security issues at wpvulndb.com",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/markri/wp-sec",
     "license": "MIT",
     "authors": [],


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
