### PR TITLE
ADD more complete json output

### DIFF
--- a/command.php
+++ b/command.php
@@ -124,9 +124,18 @@ if (!class_exists('WpSecCheck')) {
                 case self::OUTPUT_JSON:
 
                     $output = [
-                        'core' => $this->coreVulnerabilities,
-                        'plugins' => $this->pluginVulnerabilities,
-                        'themes' => $this->themeVulnerabilities,
+                        'core' => [
+                          'count'   => $this->coreVulnerabilityCount,
+                          'details' => $this->coreVulnerabilities,
+                        ],
+                        'plugins' => [
+                          'count'   => $this->pluginVulnerabilityCount,
+                          'details' => $this->pluginVulnerabilities,
+                        ],
+                        'themes' => [
+                          'count'   => $this->themeVulnerabilityCount,
+                          'details' => $this->themeVulnerabilities,
+                         ],
                     ];
 
                     WP_CLI::line(json_encode($output));

--- a/command.php
+++ b/command.php
@@ -25,8 +25,11 @@ if (!class_exists('WpSecCheck')) {
         private $outputType = true;
 
         private $coreVulnerabilityCount = 0;
+        private $coreVulnerabilities = array();
         private $pluginVulnerabilityCount = 0;
+        private $pluginVulnerabilities = array();
         private $themeVulnerabilityCount = 0;
+        private $themeVulnerabilities = array();
 
         const OUTPUT_USER = 'user';
         const OUTPUT_JSON = 'json';
@@ -121,9 +124,9 @@ if (!class_exists('WpSecCheck')) {
                 case self::OUTPUT_JSON:
 
                     $output = [
-                        'core' => $this->coreVulnerabilityCount,
-                        'plugins' => $this->pluginVulnerabilityCount,
-                        'themes' => $this->themeVulnerabilityCount,
+                        'core' => $this->coreVulnerabilities,
+                        'plugins' => $this->pluginVulnerabilities,
+                        'themes' => $this->themeVulnerabilities,
                     ];
 
                     WP_CLI::line(json_encode($output));
@@ -176,6 +179,7 @@ if (!class_exists('WpSecCheck')) {
             // Process found vulnerabilities
             $vulnerabilities = $json[$coreVersion]['vulnerabilities'];
             $this->coreVulnerabilityCount = count($vulnerabilities);
+            $this->coreVulnerabilities = $vulnerabilities;
 
             if (empty($vulnerabilities)) {
                 switch ($this->outputType) {
@@ -284,6 +288,7 @@ if (!class_exists('WpSecCheck')) {
                     }
 
                     ++$this->pluginVulnerabilityCount;
+                    $this->pluginVulnerabilities[$title][] = $vulnerability;
 
                     switch ($this->outputType) {
                         case self::OUTPUT_JSON:
@@ -377,6 +382,7 @@ if (!class_exists('WpSecCheck')) {
                     }
 
                     ++$this->themeVulnerabilityCount;
+                    $this->themeVulnerabilities[$title][] = $vulnerability;
 
                     switch ($this->outputType) {
                         case self::OUTPUT_JSON:

--- a/features/json_output.feature
+++ b/features/json_output.feature
@@ -6,5 +6,5 @@ Feature: Test that JSON output is generated
     When I run `wp wp-sec check --output=json`
     Then STDOUT should contain:
       """
-      {"core":{"count":0,"details":[]},"plugins":{"count":0,"details":[]},"themes":{"count":0,"details":[]}} 
+      {"core":{"count":0,"details":[]},"plugins":{"count":0,"details":[]},"themes":{"count":0,"details":[]}}
       """

--- a/features/json_output.feature
+++ b/features/json_output.feature
@@ -6,5 +6,5 @@ Feature: Test that JSON output is generated
     When I run `wp wp-sec check --output=json`
     Then STDOUT should contain:
       """
-      {"core":0,"plugins":0,"themes":0}
+      {"core":{"count":0,"details":[]},"plugins":{"count":0,"details":[]},"themes":{"count":0,"details":[]}} 
       """


### PR DESCRIPTION
This patch allow the `wp-sec` command to return a json object with the list of vulnerabilities and not only a count.
