### PR TITLE
ADD caching support using WP transient API as exposed from WP-CLI

### DIFF
--- a/features/json_output.feature
+++ b/features/json_output.feature
@@ -4,7 +4,16 @@ Feature: Test that JSON output is generated
     Given a WP install
 
     When I run `wp wp-sec check --output=json`
-    Then STDOUT should contain:
+
+    Then STDOUT should be a JSON object with the property: 
       """
-      {"core":{"count":0,"details":[]},"plugins":{"count":0,"details":[]},"themes":{"count":0,"details":[]}}
+      core
+      """
+    And STDOUT should be a JSON object with the property: 
+      """
+      plugins
+      """
+    And STDOUT should be a JSON object with the property: 
+      """
+      themes
       """

--- a/features/steps/then.php
+++ b/features/steps/then.php
@@ -97,6 +97,18 @@ $steps->Then( '/^STDOUT should be a JSON array containing:$/',
 		}
 });
 
+$steps->Then( '/^STDOUT should be a JSON object with the property:$/',
+	function ( $world, PyStringNode $expected ) {
+		$output = $world->result->stdout;
+		$expected = $world->replace_variables( (string) $expected );
+
+		$actualValues = json_decode( $output );
+
+		if ( !property_exists($actualValues, $expected) ) {
+			throw new \Exception( print_r(array('act' => $actualValues, 'exp' => $expected, 'res' => $world->result, 'b' => property_exists($output, 'plugins')), true) );
+		}
+});
+
 $steps->Then( '/^STDOUT should be CSV containing:$/',
 	function ( $world, TableNode $expected ) {
 		$output = $world->result->stdout;


### PR DESCRIPTION
I guess this is the simplest solution even though adding a caching layer to guzzle client maybe would be a more sound solution as the WP-CLI caching is "site" based.