### PR TITLE
Switch to WP_CLI::runcommand to validate the WP installation.

### DIFF
--- a/command.php
+++ b/command.php
@@ -179,8 +179,11 @@ if (!class_exists('WpSecCheck')) {
          */
         private function checkCoreVulnerability()
         {
-            // Get version throug internal WP_CLI command
-            $output = WP_CLI::launch_self('core version', array(), array(), false, true);
+            // Get version through internal WP_CLI command
+            $output = WP_CLI::runcommand('core version', array(
+              'return' => 'all',
+              'exit_error' => false,
+            ));
             $coreVersion = trim($output->stdout);
 
             switch ($this->outputType) {
@@ -297,7 +300,10 @@ if (!class_exists('WpSecCheck')) {
         private function checkPluginVulnerabilities()
         {
             $this->pluginVulnerabilityCount = 0;
-            $output = WP_CLI::launch_self('plugin list', array(), array('format' => 'json'), false, true);
+            $output = WP_CLI::runcommand('plugin list --format=json', array(
+              'return' => 'all',
+              'exit_error' => false,
+            ));
             $plugins = json_decode($output->stdout, true);
 
             if (null === $plugins) {
@@ -438,7 +444,10 @@ if (!class_exists('WpSecCheck')) {
         private function checkThemeVulnerabilities()
         {
             $this->themeVulnerabilityCount = 0;
-            $output = WP_CLI::launch_self('theme list', array(), array('format' => 'json'), false, true);
+            $output = WP_CLI::runcommand('theme list --format=json', array(
+              'return' => 'all',
+              'exit_error' => false,
+            ));
             $themes = json_decode($output->stdout, true);
 
             if (null === $themes) {

--- a/command.php
+++ b/command.php
@@ -79,7 +79,10 @@ if (!class_exists('WpSecCheck')) {
             $this->token = isset($assoc_args['token']) ? $assoc_args['token'] : $this->token;
 
             // Validate wordpress installation
-            $output = WP_CLI::launch_self('core is-installed', array(), array(), false, true);
+            $output = WP_CLI::runcommand('core is-installed', array(
+              'return' => 'all',
+              'exit_error' => false,
+            ));
             if ($output->return_code == 1) {
                 WP_CLI::error('No wordpress installation found');
             }


### PR DESCRIPTION
WP_CLI::runcommand() is recommended over using WP_CLI::launch_self() as
it preserves currently set environment variables. This is important as
some Wordpress installations may derive configuration, such as database
credentials, from environment variables. So, if they don't persist the
validation will fail.