### PR TITLE
Fix isVersionLessThan bug

### DIFF
--- a/command.php
+++ b/command.php
@@ -581,6 +581,10 @@ if (!class_exists('WpSecCheck')) {
          */
         private function isVersionLessThan($versionToCheck, $minimumVersion)
         {
+            if ($minimumVersion == NULL) {
+              return true;
+            }
+
             $toCheckParts = explode('.', trim($versionToCheck));
             $minimumParts = explode('.', trim($minimumVersion));
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
             "homepage": "http://wp-sec.org"
         }
     ],
-    "version": "1.0.4",
+    "version": "1.0.5",
     "minimum-stability": "stable",
     "autoload": {
         "files": [ "command.php" ]


### PR DESCRIPTION
We use the wp-sec plugin with our Wordpress clients and we discovered that isVersionLessThan was not returning true when minimumVersion was null. This means that any plugins that hadn't released patches were not showing when running wp-sec check.