### PR TITLE
Fix isVersionLessThan bug Issue #56369

### DIFF
--- a/command.php
+++ b/command.php
@@ -581,6 +581,10 @@ if (!class_exists('WpSecCheck')) {
          */
         private function isVersionLessThan($versionToCheck, $minimumVersion)
         {
+            if ($minimumVersion == NULL) {
+              return true;
+            }
+
             $toCheckParts = explode('.', trim($versionToCheck));
             $minimumParts = explode('.', trim($minimumVersion));
 


### PR DESCRIPTION
When we manually reviewed one of our clients sites, we realized that
wp-sec wasn't displaying a list of all vulnerable plugins. After
reviewing the bug, we realized that the class method isVersionLessThan()
was returning FALSE for any vulnerability that didn't have a fix (a
patched version of the plugin).